### PR TITLE
Issue 75 gpt통신 시 틀린 stage result값으로 통신하는 에러

### DIFF
--- a/src/app/stage/page.tsx
+++ b/src/app/stage/page.tsx
@@ -9,7 +9,7 @@ import { stageNumberState } from "../../components/GameDesc/GameDescBox";
 
 export default function StagePage() {
   const [stageNumber, setStageNumber] = useRecoilState<number>(stageNumberState);
-  const { question, choices } = stageNumber > 11 ? { question: undefined, choices: undefined } : questions[stageNumber - 1];
+  const { question, choices } = stageNumber === 11 ? { question: undefined, choices: undefined } : questions[stageNumber - 1];
 
   return (
     <DescWrapper>

--- a/src/components/GameDesc/GameDescBox.tsx
+++ b/src/components/GameDesc/GameDescBox.tsx
@@ -109,7 +109,7 @@ export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc }: G
     if (stageNumber === 11) {
       clickHandlerGPT();
     }
-  }, [stageNumber, clickHandlerGPT]);
+  }, [stageNumber]);
 
   return (
     <>

--- a/src/components/GameDesc/GameDescBox.tsx
+++ b/src/components/GameDesc/GameDescBox.tsx
@@ -5,6 +5,7 @@ import { atom, useRecoilState, useSetRecoilState } from "recoil";
 import { GlowText } from "../glowText/GlowText";
 import { useRouter } from "next/navigation";
 import { Loading } from "../loading/Loading";
+import { useEffect, useMemo } from "react";
 
 interface GPTResult {
   name: string;
@@ -84,23 +85,31 @@ export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc }: G
       alert(error.message);
     }
   }
+  const stageNumberMemo = useMemo(
+    () =>
+      Object.values(stageResult).reduce((accumulator, currentValue) => {
+        return accumulator + currentValue;
+      }, 1),
+    [stageResult]
+  );
+  setStageNumber(stageNumberMemo);
 
   const clickHandler = (buttonState: string) => {
-    if (stageNumber === 10) {
-      clickHandlerGPT();
-      return;
-    }
-    setStageNumber(stageNumber !== 10 ? Number(stageNumber) + 1 : Number(stageNumber));
     setStageResult((prevResult: StageResult) => {
-      const updatedResult: StageResult = { ...prevResult };
-      if (updatedResult[buttonState]) {
-        updatedResult[buttonState] += 1;
-      } else {
-        updatedResult[buttonState] = 1;
+      const updatedResult = { ...prevResult };
+      if (!updatedResult[buttonState]) {
+        updatedResult[buttonState] = 0;
       }
+      updatedResult[buttonState] += 1;
       return updatedResult;
     });
   };
+
+  useEffect(() => {
+    if (stageNumber === 11) {
+      clickHandlerGPT();
+    }
+  }, [stageNumber, clickHandlerGPT]);
 
   return (
     <>


### PR DESCRIPTION
변경점
- stageNumber관리기준을 stageResult기준으로 변경했습니다.
  - stageNumberMemo로 변수명을 변경하여 recoil의 setter를 활용하여 page코드에서 활용하도록 하였습니다.
- useMemo와 useEffect를 사용하여 상태관리를 하였습니다.
  - GPT와 통신 때 2번이상의 통신이 발생하여 dependency array위치의 GPT통신함수를 제거했습니다.



