### PR TITLE
Fix: state값이 다르게 적용되는 에러 수정

### DIFF
--- a/src/components/GameDesc/GameDescBox.tsx
+++ b/src/components/GameDesc/GameDescBox.tsx
@@ -80,8 +80,8 @@ export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc }: G
       }
       setGptResult(data);
       if (response.status === 200) {
-        setLoadingOepn(false);
         router.push("/result");
+        setLoadingOepn(false);
       }
     } catch (error: any) {
       console.error(error);
@@ -109,6 +109,9 @@ export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc }: G
 
   useEffect(() => {
     setStageNumber(stageNumberMemo);
+    if (stageNumber > 10) {
+      clickHandlerGPT();
+    }
   }, [stageNumberMemo, stageNumber]);
 
   return (
@@ -130,7 +133,7 @@ export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc }: G
           <Desc>{desc}</Desc>
           <ButtonBox>
             {buttonDesc?.map((choice, i) => (
-              <FloatButton buttonDesc={choice.text} buttonIndex={i} key={i} stageNumber={stageNumber} clickHandler={clickHandler} buttonState={choice.state} clickHandlerGPT={clickHandlerGPT} />
+              <FloatButton buttonDesc={choice.text} buttonIndex={i} key={i} clickHandler={clickHandler} buttonState={choice.state} />
             ))}
           </ButtonBox>
           {loadingOpen && <Loading />}

--- a/src/components/floatButton/FloatButton.tsx
+++ b/src/components/floatButton/FloatButton.tsx
@@ -3,19 +3,13 @@ import styled from "styled-components";
 interface FloatButtonProps {
   buttonDesc: string;
   buttonIndex: number;
-  stageNumber: number;
   clickHandler: (buttonState: string) => void;
   buttonState: string;
-  clickHandlerGPT: () => void;
 }
 
-export const FloatButton = ({ buttonDesc, stageNumber, clickHandler, buttonState, clickHandlerGPT }: FloatButtonProps) => {
+export const FloatButton = ({ buttonDesc, clickHandler, buttonState }: FloatButtonProps) => {
   const handlerButtonClick = () => {
-    if (stageNumber < 10) {
-      clickHandler(buttonState);
-    } else {
-      clickHandlerGPT();
-    }
+    clickHandler(buttonState);
   };
 
   return <FloatBtn onClick={handlerButtonClick}>{buttonDesc}</FloatBtn>;


### PR DESCRIPTION
- state값이 다르게 적용되고 있던 문제를 해결했습니다

floatButton에서 gpt를 호출하고 있던 위치를 다시 GameDescBox로 위치했습니다.


## 생각했던 점
gpt호출만 이리저리 옮기기보단 근본적인 문제가 있지 않을까라는 생각에서 출발했습니다.
GameDescBox가 해야하는 역할비중이 너무 크다고 생각합니다.
현재 컴포넌트의 흐름은 
stagePage -> GameDescBox생성 -> Float버튼 생성입니다.
1. StagePage : stageNumber를 기준으로 questions의 JSON데이터에서 필요한 정보를 가져와 GameDescbox컴포넌트에 전달합니다.
2. GameDescBox : 문제의 설명과 4가지의 선택지를 보여줍니다. FloatButton에서 클릭이벤트를 설정하는 clickHandler함수, 비동기적으로 GPT모델에 요청하는 clickHandlerGPT함수를 비롯하여 stageNumber를 기억하는 useMemo 호출시점을 지정하는 useEffect등의 hooks들이 존재합니다.
3. FloatButton : 4가지의 선택지의 버튼을 생성합니다. onClick이벤트가 있고 클릭한다면 상위 컴포넌트의 clickHandler함수를 실행하게합니다.

현재 이 3가지의 흐름이 주된 동작방식이고 GameDescBox컴포넌트에 모든 로직이 몰려있다는 느낌을 받았습니다. 
GameDescBox는 말 그대로 Description을 렌더링하는 컴포넌트로 만들어 StagePage에 로직을 반영하여 동작하는 것이 좋다고 생각하고 이후 리팩토링도 이렇게 만들고싶습니다.