### PR TITLE
Issue 103 hooks와 atom을 모듈화하여 관리하고 page단에서 모든 로직이 작동하도록 리팩토링

### DIFF
--- a/src/app/atoms/atom.tsx
+++ b/src/app/atoms/atom.tsx
@@ -37,3 +37,8 @@ export const loadingState = atom<boolean>({
   key: "loadingOpen",
   default: false,
 });
+
+export const connectedGPTState = atom<boolean>({
+  key: "connectedGPT",
+  default: false,
+});

--- a/src/app/atoms/atom.tsx
+++ b/src/app/atoms/atom.tsx
@@ -1,0 +1,39 @@
+import { atom } from "recoil";
+
+interface GPTResult {
+  prefix: string;
+  name: string;
+  description: string;
+  suitable: string;
+  unsuitable: string;
+}
+
+type StageResult = {
+  [key: string]: number;
+};
+
+export const stageResultState = atom<StageResult>({
+  key: "stageResult",
+  default: {},
+});
+
+export const gptResultState = atom<GPTResult>({
+  key: "gptResult",
+  default: {
+    prefix: "",
+    name: "",
+    description: "",
+    suitable: "",
+    unsuitable: "",
+  },
+});
+
+export const stageNumberState = atom<number>({
+  key: "stageNumber",
+  default: 1,
+});
+
+export const loadingState = atom<boolean>({
+  key: "loadingOpen",
+  default: false,
+});

--- a/src/app/hooks/hooks.tsx
+++ b/src/app/hooks/hooks.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
-import { connectedGPTState, gptResultState, loadingState, stageNumberState, stageResultState } from "../atoms/atom";
+import { gptResultState, loadingState, stageNumberState, stageResultState } from "../atoms/atom";
 import { useRouter } from "next/navigation";
 
 type StageResult = {
@@ -10,8 +10,7 @@ type StageResult = {
 export default function useStageNumber() {
   const [stageNumber, setStageNumber] = useRecoilState<number>(stageNumberState);
   const stageResult = useRecoilValue<StageResult>(stageResultState);
-  const setConnectedGPT = useSetRecoilState<boolean>(connectedGPTState);
-  const stageResultMemo = useMemo(
+  const stateResultTotalSum = useMemo(
     () =>
       Object.values(stageResult).reduce((acc, cur) => {
         return acc + cur;
@@ -19,14 +18,7 @@ export default function useStageNumber() {
     [stageResult]
   );
 
-  useEffect(() => {
-    setStageNumber(stageResultMemo);
-    if (stageNumber > 10) {
-      setConnectedGPT(true);
-    }
-  }, [stageResultMemo]);
-
-  return { stageResultMemo };
+  return { stateResultTotalSum };
 }
 
 export function useGPTHandler() {
@@ -34,7 +26,7 @@ export function useGPTHandler() {
   const [loadingOpen, setLoadingOpen] = useRecoilState<boolean>(loadingState);
   const setGptResult = useSetRecoilState(gptResultState);
 
-  async function HandlerGPT(stageResult: {}) {
+  async function gptRequestHandler(stageResult: {}) {
     try {
       setLoadingOpen(true);
       const response = await fetch("/api/generate", {
@@ -64,5 +56,5 @@ export function useGPTHandler() {
     }
   }
 
-  return { HandlerGPT, loadingOpen };
+  return { gptRequestHandler, loadingOpen };
 }

--- a/src/app/hooks/hooks.tsx
+++ b/src/app/hooks/hooks.tsx
@@ -24,7 +24,7 @@ export default function useStageNumber() {
     if (stageNumber > 10) {
       setConnectedGPT(true);
     }
-  }, [stageResultMemo, stageNumber]);
+  }, [stageResultMemo]);
 
   return { stageResultMemo };
 }

--- a/src/app/hooks/hooks.tsx
+++ b/src/app/hooks/hooks.tsx
@@ -1,25 +1,6 @@
-import { useEffect, useMemo } from "react";
-import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
-import { gptResultState, loadingState, stageNumberState, stageResultState } from "../atoms/atom";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { gptResultState, loadingState } from "../atoms/atom";
 import { useRouter } from "next/navigation";
-
-type StageResult = {
-  [key: string]: number;
-};
-
-export default function useStageNumber() {
-  const [stageNumber, setStageNumber] = useRecoilState<number>(stageNumberState);
-  const stageResult = useRecoilValue<StageResult>(stageResultState);
-  const stateResultTotalSum = useMemo(
-    () =>
-      Object.values(stageResult).reduce((acc, cur) => {
-        return acc + cur;
-      }, 1),
-    [stageResult]
-  );
-
-  return { stateResultTotalSum };
-}
 
 export function useGPTHandler() {
   const router = useRouter();

--- a/src/app/hooks/hooks.tsx
+++ b/src/app/hooks/hooks.tsx
@@ -1,21 +1,64 @@
 import { useEffect, useMemo } from "react";
-import { useRecoilState } from "recoil";
-import { stageNumberState } from "../atoms/atom";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import { gptResultState, loadingState, stageNumberState, stageResultState } from "../atoms/atom";
+import { useRouter } from "next/navigation";
 
-export function useStageNumberMemo(stageResult: {}, clickHandlerGPT: any): void {
+type StageResult = {
+  [key: string]: number;
+};
+
+export default function useStageNumber() {
   const [stageNumber, setStageNumber] = useRecoilState<number>(stageNumberState);
-  const stageNumberMemo = useMemo(
+  const stageResult = useRecoilValue<StageResult>(stageResultState);
+  const stageResultMemo = useMemo(
     () =>
-      Object.values(stageResult).reduce((accumulator, currentValue) => {
-        return accumulator + currentValue;
+      Object.values(stageResult).reduce((acc, cur) => {
+        return acc + cur;
       }, 1),
     [stageResult]
   );
 
   useEffect(() => {
-    setStageNumber(stageNumberMemo);
-    if (stageNumber > 10) {
-      clickHandlerGPT();
+    setStageNumber(stageResultMemo);
+  }, [stageResultMemo, stageNumber]);
+
+  return { stageResultMemo };
+}
+
+export function useGPTHandler() {
+  const router = useRouter();
+  const [loadingOpen, setLoadingOpen] = useRecoilState<boolean>(loadingState);
+  const setGptResult = useSetRecoilState(gptResultState);
+
+  async function HandlerGPT(stageResult: {}) {
+    try {
+      setLoadingOpen(true);
+      const response = await fetch("/api/generate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ value: stageResult }),
+      });
+
+      let data = await response.json();
+      if (response.status !== 200) {
+        throw data.error || new Error(`Request failed with status ${response.status}`);
+      }
+
+      if (typeof data === "string") {
+        data = JSON.parse(data);
+      }
+      setGptResult(data);
+      if (response.status === 200) {
+        router.push("/result");
+        setLoadingOpen(false);
+      }
+    } catch (error: any) {
+      console.error(error);
+      alert(error.message);
     }
-  }, [stageNumberMemo, stageNumber]);
+  }
+
+  return { HandlerGPT, loadingOpen };
 }

--- a/src/app/hooks/hooks.tsx
+++ b/src/app/hooks/hooks.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
-import { gptResultState, loadingState, stageNumberState, stageResultState } from "../atoms/atom";
+import { connectedGPTState, gptResultState, loadingState, stageNumberState, stageResultState } from "../atoms/atom";
 import { useRouter } from "next/navigation";
 
 type StageResult = {
@@ -10,6 +10,7 @@ type StageResult = {
 export default function useStageNumber() {
   const [stageNumber, setStageNumber] = useRecoilState<number>(stageNumberState);
   const stageResult = useRecoilValue<StageResult>(stageResultState);
+  const setConnectedGPT = useSetRecoilState<boolean>(connectedGPTState);
   const stageResultMemo = useMemo(
     () =>
       Object.values(stageResult).reduce((acc, cur) => {
@@ -20,6 +21,9 @@ export default function useStageNumber() {
 
   useEffect(() => {
     setStageNumber(stageResultMemo);
+    if (stageNumber > 10) {
+      setConnectedGPT(true);
+    }
   }, [stageResultMemo, stageNumber]);
 
   return { stageResultMemo };

--- a/src/app/hooks/hooks.tsx
+++ b/src/app/hooks/hooks.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useMemo } from "react";
+import { useRecoilState } from "recoil";
+import { stageNumberState } from "../atoms/atom";
+
+export function useStageNumberMemo(stageResult: {}, clickHandlerGPT: any): void {
+  const [stageNumber, setStageNumber] = useRecoilState<number>(stageNumberState);
+  const stageNumberMemo = useMemo(
+    () =>
+      Object.values(stageResult).reduce((accumulator, currentValue) => {
+        return accumulator + currentValue;
+      }, 1),
+    [stageResult]
+  );
+
+  useEffect(() => {
+    setStageNumber(stageNumberMemo);
+    if (stageNumber > 10) {
+      clickHandlerGPT();
+    }
+  }, [stageNumberMemo, stageNumber]);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { SponsorMessage } from "@/components/SponsorMessage/SponsorMessage";
 export default function Home() {
   return (
     <DescWrapper>
-      <GameDescBox descHeader={startPage.startHeader} startButtonDesc={startPage.startButton} buttonDesc={undefined} />
+      <GameDescBox descHeader={startPage.startHeader} startButtonDesc={startPage.startButton} buttonDesc={[]} />
       <SponsorMessage />
     </DescWrapper>
   );

--- a/src/app/registry.tsx
+++ b/src/app/registry.tsx
@@ -5,8 +5,6 @@ import { useServerInsertedHTML } from "next/navigation";
 import { ServerStyleSheet, StyleSheetManager } from "styled-components";
 
 export default function StyledComponentsRegistry({ children }: { children: React.ReactNode }) {
-  // Only create stylesheet once with lazy initial state
-  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
   const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
 
   useServerInsertedHTML(() => {

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -8,7 +8,7 @@ import { ResultButton } from "../../components/floatButton/ResultButton";
 import { ShareModal } from "../../components/shareModal/ShareModal";
 import Link from "next/link";
 import { useRecoilValue } from "recoil";
-import { gptResultState } from "@/components/GameDesc/GameDescBox";
+import { gptResultState } from "../atoms/atom";
 
 interface ContentFontProp {
   size: number;
@@ -61,16 +61,6 @@ export default function ResultPage() {
           </SimilarBox>
         </SimilarContainer>
         <ButtonBox>
-          {/* <ResultButton
-            clickHandler={() => {
-              setModalOpen(true);
-            }}
-            buttonDesc="공유하기"
-          />
-          <ResultButton
-            clickHandler={handleDownload}
-            buttonDesc="다운로드"
-          /> */}
           <Link href="/">
             <ResultButton buttonDesc="다시하기" />
           </Link>

--- a/src/app/stage/page.tsx
+++ b/src/app/stage/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import React from "react";
-import { useEffect } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { styled } from "styled-components";
 import { loadingState, stageNumberState, stageResultState } from "../atoms/atom";
@@ -8,7 +7,7 @@ import { ProgressBar } from "@/components/progressBar/ProgressBar";
 import { GameDescBox } from "@/components/GameDesc/GameDescBox";
 import { Loading } from "@/components/loading/Loading";
 import questions from "../../question.json";
-import useStageNumber, { useGPTHandler } from "../hooks/hooks";
+import { useGPTHandler } from "../hooks/hooks";
 
 type StageResult = {
   [key: string]: number;
@@ -20,23 +19,23 @@ export default function StagePage() {
   const setStageNumber = useSetRecoilState<number>(stageNumberState);
   const loadingOpen = useRecoilValue<boolean>(loadingState);
   const { question, choices } = stageNumber === 11 ? { question: undefined, choices: undefined } : questions[stageNumber - 1];
-  const { stateResultTotalSum } = useStageNumber();
   const { gptRequestHandler } = useGPTHandler();
 
   const clickHandler = (buttonState: string) => {
-    setStageNumber(stageNumber + 1);
-    setStageResult((prevResult: StageResult) => {
-      const updatedResult = { ...prevResult };
-      if (!updatedResult[buttonState]) {
-        updatedResult[buttonState] = 0;
-      }
-      updatedResult[buttonState] += 1;
-      return updatedResult;
-    });
+    setStageNumber((prev) => prev + 1);
 
-    if (stateResultTotalSum === 10) {
-      gptRequestHandler(stageResult);
+    const updatedResult = { ...stageResult };
+    if (!updatedResult[buttonState]) {
+      updatedResult[buttonState] = 0;
     }
+    updatedResult[buttonState] += 1;
+
+    const stageResultSum = Object.values(updatedResult).reduce((acc, cur) => acc + cur, 0);
+    if (stageResultSum === 10) {
+      gptRequestHandler(updatedResult);
+    }
+
+    setStageResult(updatedResult);
   };
 
   return (

--- a/src/app/stage/page.tsx
+++ b/src/app/stage/page.tsx
@@ -1,11 +1,9 @@
 "use client";
-import React, { useState } from "react";
+import React from "react";
 import { useEffect } from "react";
-import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue } from "recoil";
 import { styled } from "styled-components";
-import { useRouter } from "next/navigation";
-import { gptResultState, loadingState, stageNumberState, stageResultState } from "../atoms/atom";
-// import { stageNumberMemo, useStageNumberMemo } from "../hooks/hooks";
+import { connectedGPTState, loadingState, stageNumberState, stageResultState } from "../atoms/atom";
 import { ProgressBar } from "@/components/progressBar/ProgressBar";
 import { GameDescBox } from "@/components/GameDesc/GameDescBox";
 import { Loading } from "@/components/loading/Loading";
@@ -17,22 +15,19 @@ type StageResult = {
 };
 
 export default function StagePage() {
-  const router = useRouter();
-  const setGptResult = useSetRecoilState(gptResultState);
   const stageResult = useRecoilValue<StageResult>(stageResultState);
-  const [stageNumber, setStageNumber] = useRecoilState<number>(stageNumberState);
-  const [loadingOpen, setLoadingOpen] = useRecoilState<boolean>(loadingState);
-  const [gptCall, setGptCall] = useState<boolean>(false);
+  const stageNumber = useRecoilValue<number>(stageNumberState);
+  const loadingOpen = useRecoilValue<boolean>(loadingState);
+  const connectedGPT = useRecoilValue<boolean>(connectedGPTState);
   const { question, choices } = stageNumber === 11 ? { question: undefined, choices: undefined } : questions[stageNumber - 1];
   const { stageResultMemo } = useStageNumber();
   const { HandlerGPT } = useGPTHandler();
 
   useEffect(() => {
-    if (stageNumber > 10 && !gptCall) {
-      setGptCall(true);
+    if (connectedGPT === true) {
       HandlerGPT(stageResult);
     }
-  }, [stageResultMemo, stageResult, HandlerGPT, gptCall]);
+  }, [stageNumber, connectedGPT]);
 
   return (
     <>

--- a/src/app/stage/page.tsx
+++ b/src/app/stage/page.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useEffect } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { styled } from "styled-components";
-import { loadingState, questionIndexState, stageNumberState, stageResultState } from "../atoms/atom";
+import { loadingState, stageNumberState, stageResultState } from "../atoms/atom";
 import { ProgressBar } from "@/components/progressBar/ProgressBar";
 import { GameDescBox } from "@/components/GameDesc/GameDescBox";
 import { Loading } from "@/components/loading/Loading";

--- a/src/app/stage/page.tsx
+++ b/src/app/stage/page.tsx
@@ -1,9 +1,9 @@
 "use client";
-import React, { useCallback, useMemo } from "react";
+import React from "react";
 import { useEffect } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { styled } from "styled-components";
-import { connectedGPTState, loadingState, stageNumberState, stageResultState } from "../atoms/atom";
+import { loadingState, questionIndexState, stageNumberState, stageResultState } from "../atoms/atom";
 import { ProgressBar } from "@/components/progressBar/ProgressBar";
 import { GameDescBox } from "@/components/GameDesc/GameDescBox";
 import { Loading } from "@/components/loading/Loading";
@@ -19,12 +19,12 @@ export default function StagePage() {
   const stageNumber = useRecoilValue<number>(stageNumberState);
   const setStageNumber = useSetRecoilState<number>(stageNumberState);
   const loadingOpen = useRecoilValue<boolean>(loadingState);
-  const connectedGPT = useRecoilValue<boolean>(connectedGPTState);
   const { question, choices } = stageNumber === 11 ? { question: undefined, choices: undefined } : questions[stageNumber - 1];
-  // const { stageResultMemo } = useStageNumber();
-  const { HandlerGPT } = useGPTHandler();
+  const { stateResultTotalSum } = useStageNumber();
+  const { gptRequestHandler } = useGPTHandler();
 
   const clickHandler = (buttonState: string) => {
+    setStageNumber(stageNumber + 1);
     setStageResult((prevResult: StageResult) => {
       const updatedResult = { ...prevResult };
       if (!updatedResult[buttonState]) {
@@ -33,16 +33,11 @@ export default function StagePage() {
       updatedResult[buttonState] += 1;
       return updatedResult;
     });
-  };
 
-  useEffect(() => {
-    const stageResultMemo = Object.values(stageResult).reduce((acc, cur) => acc + cur, 1);
-    setStageNumber(stageResultMemo);
-    console.log(stageResult);
-    if (stageNumber === 10) {
-      HandlerGPT(stageResult);
+    if (stateResultTotalSum === 10) {
+      gptRequestHandler(stageResult);
     }
-  }, [stageResult]);
+  };
 
   return (
     <>

--- a/src/components/GameDesc/GameDescBox.tsx
+++ b/src/components/GameDesc/GameDescBox.tsx
@@ -15,36 +15,6 @@ interface GPTResult {
   unsuitable: string;
 }
 
-const stageResultState = atom<StageResult>({
-  key: "stageResult",
-  default: {},
-});
-
-export const gptResultState = atom<GPTResult>({
-  key: "gptResult",
-  default: {
-    prefix: "",
-    name: "",
-    description: "",
-    suitable: "",
-    unsuitable: "",
-  },
-});
-
-export const stageNumberState = atom<number>({
-  key: "stageNumber",
-  default: 1,
-});
-
-export const loadingState = atom<boolean>({
-  key: "loadingOpen",
-  default: false,
-});
-
-type StageResult = {
-  [key: string]: number;
-};
-
 interface GameDescBoxProps {
   descHeader: string;
   desc?: string;
@@ -53,67 +23,6 @@ interface GameDescBoxProps {
 }
 
 export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc }: GameDescBoxProps) => {
-  const router = useRouter();
-  const setGptResult = useSetRecoilState(gptResultState);
-  const [stageResult, setStageResult] = useRecoilState<StageResult>(stageResultState);
-  const [stageNumber, setStageNumber] = useRecoilState<number>(stageNumberState);
-  const [loadingOpen, setLoadingOepn] = useRecoilState<boolean>(loadingState);
-
-  async function clickHandlerGPT() {
-    try {
-      setLoadingOepn(true);
-      const response = await fetch("/api/generate", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ value: stageResult }),
-      });
-
-      let data = await response.json();
-      if (response.status !== 200) {
-        throw data.error || new Error(`Request failed with status ${response.status}`);
-      }
-
-      if (typeof data === "string") {
-        data = JSON.parse(data);
-      }
-      setGptResult(data);
-      if (response.status === 200) {
-        router.push("/result");
-        setLoadingOepn(false);
-      }
-    } catch (error: any) {
-      console.error(error);
-      alert(error.message);
-    }
-  }
-  const stageNumberMemo = useMemo(
-    () =>
-      Object.values(stageResult).reduce((accumulator, currentValue) => {
-        return accumulator + currentValue;
-      }, 1),
-    [stageResult]
-  );
-
-  const clickHandler = (buttonState: string) => {
-    setStageResult((prevResult: StageResult) => {
-      const updatedResult = { ...prevResult };
-      if (!updatedResult[buttonState]) {
-        updatedResult[buttonState] = 0;
-      }
-      updatedResult[buttonState] += 1;
-      return updatedResult;
-    });
-  };
-
-  useEffect(() => {
-    setStageNumber(stageNumberMemo);
-    if (stageNumber > 10) {
-      clickHandlerGPT();
-    }
-  }, [stageNumberMemo, stageNumber]);
-
   return (
     <>
       <GlowText size={40} desc={descHeader} />
@@ -133,10 +42,9 @@ export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc }: G
           <Desc>{desc}</Desc>
           <ButtonBox>
             {buttonDesc?.map((choice, i) => (
-              <FloatButton buttonDesc={choice.text} buttonIndex={i} key={i} clickHandler={clickHandler} buttonState={choice.state} />
+              <FloatButton buttonDesc={choice.text} key={i} buttonState={choice.state} />
             ))}
           </ButtonBox>
-          {loadingOpen && <Loading />}
         </>
       )}
     </>

--- a/src/components/GameDesc/GameDescBox.tsx
+++ b/src/components/GameDesc/GameDescBox.tsx
@@ -8,9 +8,10 @@ interface GameDescBoxProps {
   desc?: string;
   startButtonDesc?: string;
   buttonDesc: { text: string; state: string }[] | undefined;
+  clickHandler: (buttonState: string) => void;
 }
 
-export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc }: GameDescBoxProps) => {
+export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc, clickHandler }: GameDescBoxProps) => {
   return (
     <>
       <GlowText size={40} desc={descHeader} />
@@ -30,7 +31,7 @@ export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc }: G
           <Desc>{desc}</Desc>
           <ButtonBox>
             {buttonDesc?.map((choice, i) => (
-              <FloatButton buttonDesc={choice.text} key={i} buttonState={choice.state} />
+              <FloatButton buttonDesc={choice.text} key={i} buttonState={choice.state} clickHandler={clickHandler} />
             ))}
           </ButtonBox>
         </>

--- a/src/components/GameDesc/GameDescBox.tsx
+++ b/src/components/GameDesc/GameDescBox.tsx
@@ -7,8 +7,8 @@ interface GameDescBoxProps {
   descHeader: string;
   desc?: string;
   startButtonDesc?: string;
-  buttonDesc: { text: string; state: string }[] | undefined;
-  clickHandler: (buttonState: string) => void;
+  buttonDesc?: { text: string; state: string }[] | undefined;
+  clickHandler?: (buttonState: string) => void;
 }
 
 export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc, clickHandler }: GameDescBoxProps) => {
@@ -31,7 +31,7 @@ export const GameDescBox = ({ descHeader, desc, startButtonDesc, buttonDesc, cli
           <Desc>{desc}</Desc>
           <ButtonBox>
             {buttonDesc?.map((choice, i) => (
-              <FloatButton buttonDesc={choice.text} key={i} buttonState={choice.state} clickHandler={clickHandler} />
+              <FloatButton buttonDesc={choice.text} key={i} buttonState={choice.state} clickHandler={clickHandler ? (state: string) => clickHandler(state) : undefined} />
             ))}
           </ButtonBox>
         </>

--- a/src/components/GameDesc/GameDescBox.tsx
+++ b/src/components/GameDesc/GameDescBox.tsx
@@ -1,19 +1,7 @@
 import { styled } from "styled-components";
 import { FloatButton } from "../floatButton/FloatButton";
 import { StartButton } from "../floatButton/StartButton";
-import { atom, useRecoilState, useSetRecoilState } from "recoil";
 import { GlowText } from "../glowText/GlowText";
-import { useRouter } from "next/navigation";
-import { Loading } from "../loading/Loading";
-import { useEffect, useMemo } from "react";
-
-interface GPTResult {
-  prefix: string;
-  name: string;
-  description: string;
-  suitable: string;
-  unsuitable: string;
-}
 
 interface GameDescBoxProps {
   descHeader: string;

--- a/src/components/floatButton/FloatButton.tsx
+++ b/src/components/floatButton/FloatButton.tsx
@@ -1,30 +1,12 @@
-import { stageResultState } from "@/app/atoms/atom";
-import { useSetRecoilState } from "recoil";
 import styled from "styled-components";
 
 interface FloatButtonProps {
   buttonDesc: string;
   buttonState: string;
+  clickHandler: (buttonState: string) => void;
 }
 
-type StageResult = {
-  [key: string]: number;
-};
-
-export const FloatButton = ({ buttonDesc, buttonState }: FloatButtonProps) => {
-  const setStageResult = useSetRecoilState<StageResult>(stageResultState);
-
-  const clickHandler = (buttonState: string) => {
-    setStageResult((prevResult: StageResult) => {
-      const updatedResult = { ...prevResult };
-      if (!updatedResult[buttonState]) {
-        updatedResult[buttonState] = 0;
-      }
-      updatedResult[buttonState] += 1;
-      return updatedResult;
-    });
-  };
-
+export const FloatButton = ({ buttonDesc, buttonState, clickHandler }: FloatButtonProps) => {
   return <FloatBtn onClick={() => clickHandler(buttonState)}>{buttonDesc}</FloatBtn>;
 };
 

--- a/src/components/floatButton/FloatButton.tsx
+++ b/src/components/floatButton/FloatButton.tsx
@@ -1,18 +1,32 @@
+import { stageResultState } from "@/app/atoms/atom";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 
 interface FloatButtonProps {
   buttonDesc: string;
-  buttonIndex: number;
-  clickHandler: (buttonState: string) => void;
   buttonState: string;
 }
 
-export const FloatButton = ({ buttonDesc, clickHandler, buttonState }: FloatButtonProps) => {
-  const handlerButtonClick = () => {
-    clickHandler(buttonState);
+type StageResult = {
+  [key: string]: number;
+};
+
+export const FloatButton = ({ buttonDesc, buttonState }: FloatButtonProps) => {
+  // const setStageResult = useRecoilState();
+  const setStageResult = useSetRecoilState<StageResult>(stageResultState);
+
+  const clickHandler = (buttonState: string) => {
+    setStageResult((prevResult: StageResult) => {
+      const updatedResult = { ...prevResult };
+      if (!updatedResult[buttonState]) {
+        updatedResult[buttonState] = 0;
+      }
+      updatedResult[buttonState] += 1;
+      return updatedResult;
+    });
   };
 
-  return <FloatBtn onClick={handlerButtonClick}>{buttonDesc}</FloatBtn>;
+  return <FloatBtn onClick={() => clickHandler(buttonState)}>{buttonDesc}</FloatBtn>;
 };
 
 const FloatBtn = styled.button`

--- a/src/components/floatButton/FloatButton.tsx
+++ b/src/components/floatButton/FloatButton.tsx
@@ -1,5 +1,5 @@
 import { stageResultState } from "@/app/atoms/atom";
-import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import styled from "styled-components";
 
 interface FloatButtonProps {
@@ -12,7 +12,6 @@ type StageResult = {
 };
 
 export const FloatButton = ({ buttonDesc, buttonState }: FloatButtonProps) => {
-  // const setStageResult = useRecoilState();
   const setStageResult = useSetRecoilState<StageResult>(stageResultState);
 
   const clickHandler = (buttonState: string) => {

--- a/src/components/floatButton/FloatButton.tsx
+++ b/src/components/floatButton/FloatButton.tsx
@@ -3,11 +3,11 @@ import styled from "styled-components";
 interface FloatButtonProps {
   buttonDesc: string;
   buttonState: string;
-  clickHandler: (buttonState: string) => void;
+  clickHandler?: (buttonState: string) => void;
 }
 
 export const FloatButton = ({ buttonDesc, buttonState, clickHandler }: FloatButtonProps) => {
-  return <FloatBtn onClick={() => clickHandler(buttonState)}>{buttonDesc}</FloatBtn>;
+  return <FloatBtn onClick={() => clickHandler && clickHandler(buttonState)}>{buttonDesc}</FloatBtn>;
 };
 
 const FloatBtn = styled.button`


### PR DESCRIPTION
- 현재 GameDescBox에서 호출, 작동하는 로직을 page로 이동시켰습니다.
- Atom들과 사용되는 hook을 모듈화하여 원하는 시점에 호출하여 사용하도록 했습니다.

--- 질문점 ---
1. 현재 hook을 모듈화 하는 과정에서 useMemo로 저장된 값을 useEffect에 사용해야하기에 useStageNumberMemo라는 함수에 묶어서 호출하여 한번에 작동하도록 만들었습니다. 이런 과정이 맞는지 의문점이 생겨 질문드립니다. 🥲

--- 문제점 ---
이전에 문제가 되었던 (GPT로 넘어가는 총 결과값이 9로 넘어가는 이슈)가 page단으로 옮기면서 해결되었습니다. 하지만 GPT가 정확한 결과값을 전달하여도 일정한 답변(루나 러브굿)만 출력하는 모습을 보았습니다. 이에 대한 해결점이 필요해보입니다.

--- 0814 변경점 ---
- customhook으로 리팩토링하여 원하는 시점에 호출되도록 수정
- stageNumber를 기준으로 GPT와 통신하는 것을 connectedGPT라는 상태를 기준으로 통신하도록 리팩토링