### PR TITLE
Issue 136 [유저피드백] 카카오환경에서 화면 짤림 현상 수정

### DIFF
--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -77,7 +77,8 @@ const ResultBox = styled.div`
   align-items: center;
   width: 100%;
   max-width: 1000px;
-  max-height: 900px;
+  max-height: 100vh;
+  padding-top: 3rem;
   border-radius: 20px;
   background-image: linear-gradient(rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.8)), url("img/harry.jpeg");
   background-position: center;

--- a/src/components/loading/Loading.tsx
+++ b/src/components/loading/Loading.tsx
@@ -5,16 +5,9 @@ import { keyframes, styled } from "styled-components";
 export const Loading = () => {
   return (
     <Overlay>
-      <GlowText>
-        Loading...
-      </GlowText>
+      <GlowText>Loading...</GlowText>
       <LottieContainer>
-        <Lottie
-          loop
-          animationData={loading}
-          play
-          style={{ width: 600, height: 560 }}
-        />
+        <Lottie className="lottie-animation" loop animationData={loading} play />
       </LottieContainer>
     </Overlay>
   );
@@ -42,14 +35,22 @@ const glow = keyframes`
   }
 `;
 const GlowText = styled.span`
-color: white;
-font-size: 50px;
-text-align: center;
-animation: ${glow} 1.5s ease-in-out infinite alternate;
-@media (max-width: 800px) {
+  color: white;
+  font-size: 50px;
+  text-align: center;
+  animation: ${glow} 1.5s ease-in-out infinite alternate;
+  @media (max-width: 800px) {
     font-size: 5vh;
-}
-`
+  }
+`;
 const LottieContainer = styled.div`
-    margin-top: -100px;
-`
+  .lottie-animation {
+    width: 600px;
+    height: 560px;
+
+    @media (max-width: 550px) {
+      width: 100%;
+      height: auto;
+    }
+  }
+`;


### PR DESCRIPTION
https://github.com/f-lab-edu/Find_Character_GPT/issues/136 에대한 문제 해결

## 수정 내용
- resultPage의 height높이를 px에서 vh로 고쳐 window크기에 맞는 화면 제공
- lottie 가로 이미지가 짤리는 이슈를 새로운 class를 추가하며 조절하도록 수정